### PR TITLE
Python 3.7 compatability

### DIFF
--- a/thorn/events.py
+++ b/thorn/events.py
@@ -278,9 +278,7 @@ class ModelEvent(Event):
         # database fields before saving, a pre_save signal
         # handles this, but we want to avoid the extra database hit
         # when they are not in use.
-        self.use_transitions = any(
-            '__now_' in k for k in keys(self.filter_fields),
-        )
+        self.use_transitions = any('__now_' in k for k in keys(self.filter_fields))
         # _filterargs is set by __reduce__ to restore *args
         restored_args = kwargs.get('_filterargs') or ()
         self._init_attrs(**kwargs)


### PR DESCRIPTION
Fixes error "SyntaxError: Generator expression must be parenthesized"